### PR TITLE
ci: actions/checkout v7 へ更新（Node 20 deprecation）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
           version: 9
@@ -39,7 +39,7 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod


### PR DESCRIPTION
checkout@v4 は Node 20 ランタイム。dependabot の更新 PR が未作成だったため手動対応（org 内の他リポは v6/v7 標準）。actionlint パス済み。