### PR TITLE
chore: 共通の日本語PRテンプレートへ統一

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-## Summary
-
-## Changes
-
-## Test plan
-- [ ]


### PR DESCRIPTION
## 概要

アカウント共通の日本語PRテンプレートを使用するため、リポジトリ固有の簡易英語テンプレートを削除します。

## 変更内容

- `.github/pull_request_template.md` のローカル上書きを削除
- `akaitigo/.github` の共通テンプレートへフォールバック

## 検証結果

- [x] 共通テンプレートが公開済みであることを確認
- [x] GitHubのテンプレート優先順位を公式ドキュメントで確認

## 影響範囲

コードとビルドへの影響はありません。今後作成するPRの本文が日本語の共通形式になります。